### PR TITLE
Record invocations for stubs with stub_everything = true

### DIFF
--- a/lib/bourne/mock.rb
+++ b/lib/bourne/mock.rb
@@ -16,6 +16,14 @@ module Mocha # :nodoc:
           message = UnexpectedInvocation.new(self, symbol, *arguments).to_s
           message << Mockery.instance.mocha_inspect
           raise ExpectationError.new(message, caller)
+        else   
+          target = if self.respond_to? :mocha
+            self.mocha
+          else
+            mocha
+          end
+          Mockery.instance.invocation(target, symbol, arguments)
+          nil
         end
       end
     end

--- a/test/acceptance/spy_test.rb
+++ b/test/acceptance/spy_test.rb
@@ -142,3 +142,19 @@ class PureSpyTest < Test::Unit::TestCase
     stub
   end
 end
+
+class StubEverythingSpyTest < Test::Unit::TestCase
+  include AcceptanceTest
+  def setup
+    setup_acceptance_test
+  end
+  
+  def teardown
+    teardown_acceptance_test
+  end  
+  def test_should_match_invocations_with_no_explicit_stubbing
+    instance = stub_everything
+    instance.surprise!
+    assert_received(instance, :surprise!)
+  end
+end


### PR DESCRIPTION
Allows invocations to be recorded for stubs created using stub_everything e.g.

```
describe "mock" do
  context "with stub_everything = true" do
    before do
      @person = stub_everything
      @person.welcome
    end

    it "should record all invocations" do
      @person.should have_received(:welcome)
    end
  end
end
```
