### PR TITLE
Mention when a method with an expectation is unstubbed. Fixes #5.

### DIFF
--- a/lib/bourne/api.rb
+++ b/lib/bourne/api.rb
@@ -51,7 +51,9 @@ module Mocha # :nodoc:
       end
 
       def failure_message
-        @expectation.mocha_inspect
+        message  = ""
+        message << "unstubbed, " if matching_stubs.length == 0
+        message << @expectation.mocha_inspect
       end
 
       private
@@ -69,6 +71,12 @@ module Mocha # :nodoc:
       def invocations
         Mockery.instance.invocations.select do |invocation|
           invocation.mock.equal?(@mock)
+        end
+      end
+
+      def matching_stubs
+        Mockery.instance.stubba.stubba_methods.select do |method|
+          method.mock.equal?(@mock) && method.method == @expected_method_name
         end
       end
     end

--- a/test/acceptance/spy_test.rb
+++ b/test/acceptance/spy_test.rb
@@ -95,6 +95,12 @@ module SpyTestMethods
     flunk("Expected to fail")
   end
 
+  def test_should_warn_for_unstubbed_methods_with_expectations
+    new_instance.stubs(:unknown)
+
+    assert_fails(/unstubbed, expected exactly once/) { assert_matcher_accepts have_received(:unknown), new_instance }
+  end
+
   def test_should_reject_not_enough_calls
     instance = new_instance
     instance.stubs(:magic)


### PR DESCRIPTION
Not sure if this is the best message, but it works.
