### PR TITLE
Switch from require 'mocha' to require 'mocha/api' as suggested by the library.

### DIFF
--- a/lib/bourne.rb
+++ b/lib/bourne.rb
@@ -1,2 +1,2 @@
-require 'mocha'
+require 'mocha/api'
 require 'bourne/api'


### PR DESCRIPTION
This change avoids the deprecations in [mocha/integration.rb](https://github.com/freerange/mocha/blob/master/lib/mocha/integration.rb), which don't appear in the bourne test suite.
