### PR TITLE
Depend on mocha 0.13.0

### DIFF
--- a/bourne.gemspec
+++ b/bourne.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('mocha', '0.12.7') # follow instructions in mock.rb to update
+  s.add_dependency('mocha', '0.13.0') # follow instructions in mock.rb to update
 
   s.add_development_dependency('rake')
 end

--- a/lib/bourne.rb
+++ b/lib/bourne.rb
@@ -1,2 +1,2 @@
-require 'mocha'
+require 'mocha/api'
 require 'bourne/api'

--- a/test/acceptance/mocha_example_test.rb
+++ b/test/acceptance/mocha_example_test.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../test_helper', __FILE__)
-require 'mocha'
+require 'mocha/setup'
 
 class MochaExampleTest < Test::Unit::TestCase
 

--- a/test/acceptance/stubba_example_test.rb
+++ b/test/acceptance/stubba_example_test.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../test_helper', __FILE__)
-require 'mocha'
+require 'mocha/setup'
 
 class Widget
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,7 @@ if ENV['MOCHA_OPTIONS'] == 'use_test_unit_gem'
 end
 
 require 'test/unit'
-require 'mocha'
+require 'mocha/setup'
 
 if defined?(MiniTest)
   FailedAssertion = MiniTest::Assertion

--- a/test/unit/assert_received_test.rb
+++ b/test/unit/assert_received_test.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), "..", "test_helper")
 require 'test_runner'
 require 'bourne/api'
 require 'bourne/mockery'
-require 'mocha/object'
+require 'mocha/api'
 
 class AssertReceivedTest < Test::Unit::TestCase
 

--- a/test/unit/have_received_test.rb
+++ b/test/unit/have_received_test.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), "..", "test_helper")
 require 'test_runner'
 require 'bourne/api'
 require 'bourne/mockery'
-require 'mocha/object'
+require 'mocha/api'
 require 'matcher_helpers'
 
 module HaveReceivedTestMethods


### PR DESCRIPTION
There have been no changes to mock.rb since we last updated it: https://github.com/freerange/mocha/blob/v0.13.0/lib/mocha/mock.rb
- Change to `require "mocha/setup"` per release notes for 0.13.0:
  http://gofreerange.com/mocha/docs/file.RELEASE.html
- This gets rid of these annoying errors:

```
*** Mocha deprecation warning: Test::Unit or MiniTest must be loaded *before* Mocha.


*** Mocha deprecation warning: If you're integrating with a test library other than Test::Unit or MiniTest, you should use `require 'mocha/api'` instead of `require 'mocha'`.
```
