### PR TITLE
Depend on a minor version of mocha instead of strict.

### DIFF
--- a/bourne.gemspec
+++ b/bourne.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('mocha', '0.13.2') # follow instructions in mock.rb to update
+  s.add_dependency('mocha', '~> 0.13.2') # follow instructions in mock.rb to update
 
   s.add_development_dependency('rake')
 end


### PR DESCRIPTION
Spoke with @jferris yesterday about this and the code changes he has made recently should allow us to remove the strict version dependency.

This should resolve some of the issues we have in shoulda-matchers with depending on bourne.
