### PR TITLE
Make assertions against correct exception class for test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ rvm:
 
 matrix:
   allow_failures:
-    - rvm: 2.0.0
+    - rvm: rbx-19mode

--- a/test/unit/mockery_test.rb
+++ b/test/unit/mockery_test.rb
@@ -32,14 +32,14 @@ class MockeryTest < Test::Unit::TestCase
     mock_2 = mockery.named_mock('mock-2') { expects(:method_2) }
     1.times { mock_1.method_1 }
     0.times { mock_2.method_2 }
-    assert_raises(ExpectationError) { mockery.verify }
+    assert_raises(ExpectationErrorFactory.exception_class) { mockery.verify }
   end
 
   def test_should_reset_list_of_mocks_on_teardown
     mockery = Mockery.new
     mock = mockery.unnamed_mock { expects(:my_method) }
     mockery.teardown
-    assert_nothing_raised(ExpectationError) { mockery.verify }
+    assert_nothing_raised(ExpectationErrorFactory.exception_class) { mockery.verify }
   end
 
   def test_should_build_instance_of_stubba_on_instantiation


### PR DESCRIPTION
Mocha does not raise ExpectationError when run from MiniTest. Change our
assertions to go against whatever Mocha is using for failed expectations. This change brings the entire suite green on MRI 2.0.0p0
