### PR TITLE
Allow mocha 0.14.*

### DIFF
--- a/bourne.gemspec
+++ b/bourne.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('mocha', '~> 0.13.2') # follow instructions in mock.rb to update
+  s.add_dependency('mocha', '>= 0.13.2', '< 0.15') # follow instructions in mock.rb to update
 
   s.add_development_dependency('rake')
 end


### PR DESCRIPTION
Allows using mocha 0.14.*, which allows using minitest v5.
